### PR TITLE
Drop cleanup commands

### DIFF
--- a/io.gitlab.adhami3310.Impression.json
+++ b/io.gitlab.adhami3310.Impression.json
@@ -21,17 +21,6 @@
             "CARGO_HOME": "/run/build/impression/cargo"
         }
     },
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
         {
             "name": "impression",


### PR DESCRIPTION
These commands are mostly related to C and Vala apps.

They are irrelevant for Rust apps.